### PR TITLE
Build with GHC 8.2 and 8.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ cache:
 # Build matrix.
 matrix:
   include:
+    - env: GHCVER=8.4.2 STACK_YAML=stack-8.4.yaml
+      compiler: GHC-8.4.2
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.4.2
+
     - env: GHCVER=8.2.2 STACK_YAML=stack.yaml
       compiler: GHC-8.2.2
       addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,16 @@ cache:
 # Build matrix.
 matrix:
   include:
-    - env: GHCVER=8.0.2 STACK_YAML=stack.yaml
+    - env: GHCVER=8.2.2 STACK_YAML=stack.yaml
+      compiler: GHC-8.2.2
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.2.2
+
+    - env: GHCVER=8.0.2 STACK_YAML=stack-8.0.yaml
       compiler: GHC-8.0.2
       addons:
         apt:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -29,7 +29,7 @@ library
     src
   build-depends:
       base        >= 4.7    && <= 5
-    , cereal      >= 0.4.0  && <  0.5.5
+    , cereal      >= 0.4.0  && <  0.5.6
     , bytestring  >= 0.9.0  && <= 0.12.0
     , containers  >= 0.5.0  && <= 0.6.0
     , string-conv >= 0.1    && <= 0.2

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -64,7 +64,14 @@ test-suite spec
   default-language:
     Haskell2010
   other-modules:
-    Spec
+    Data.Ruby.Marshal
+    Data.Ruby.Marshal.Encoding
+    Data.Ruby.Marshal.Get
+    Data.Ruby.Marshal.Int
+    Data.Ruby.Marshal.Monad
+    Data.Ruby.Marshal.RubyObject
+    Data.Ruby.Marshal.Types
+    MarshalSpec
   main-is:
     Spec.hs
   type:

--- a/stack-8.0.yaml
+++ b/stack-8.0.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.4
+resolver: lts-9.13
 packages:
 - '.'
 extra-deps: []

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -1,0 +1,6 @@
+resolver: nightly-2018-05-18
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-10.4
+resolver: lts-11.9
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
- Bumped upper version bound of `cereal` to make it build on newer Stackage LTS.
- Fixed `other-modules` in cabal file
- Added GHC 8.2 and 8.4 to `.travis.yml`