### PR TITLE
Update to latest Stack LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,15 @@ cache:
 # Build matrix.
 matrix:
   include:
+    - env: GHCVER=8.6.5 STACK_YAML=stack.yaml
+      compiler: GHC-8.6.5
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.6.5
+
     - env: GHCVER=8.4.2 STACK_YAML=stack-8.4.yaml
       compiler: GHC-8.4.2
       addons:
@@ -18,7 +27,7 @@ matrix:
           packages:
             - ghc-8.4.2
 
-    - env: GHCVER=8.2.2 STACK_YAML=stack.yaml
+    - env: GHCVER=8.2.2 STACK_YAML=stack-8.2.yaml
       compiler: GHC-8.2.2
       addons:
         apt:
@@ -44,15 +53,6 @@ matrix:
             - hvr-ghc
           packages:
             - ghc-7.10.3
-
-    - env: GHCVER=7.8.4 STACK_YAML=stack-7.8.yaml
-      compiler: GHC-7.8.4
-      addons:
-        apt:
-          sources:
-            - hvr-ghc
-          packages:
-            - ghc-7.8.4
 
 # Download and unpack stack.
 before_install:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -1,5 +1,5 @@
 name: ruby-marshal
-version: 0.1.2
+version: 0.1.3
 synopsis: Parse a subset of Ruby objects serialised with Marshal.dump.
 description: Parse a subset of Ruby objects serialised with Marshal.dump.
 homepage: https://github.com/filib/ruby-marshal
@@ -9,7 +9,7 @@ author: Philip Cunningham
 maintainer: hello@filib.io
 category: Data
 build-type: Simple
-tested-with: GHC == 7.8, GHC == 7.10
+tested-with: GHC == 7.8, GHC == 7.10, GHC == 8.6.5
 cabal-version: >= 1.10
 extra-source-files: CHANGELOG.md
 
@@ -29,9 +29,9 @@ library
     src
   build-depends:
       base        >= 4.7    && <= 5
-    , cereal      >= 0.4.0  && <  0.5.6
+    , cereal      >= 0.4.0  && <  0.6.0
     , bytestring  >= 0.9.0  && <= 0.12.0
-    , containers  >= 0.5.0  && <= 0.6.0
+    , containers  >= 0.5.0  && <= 0.7.0
     , string-conv >= 0.1    && <= 0.2
     , mtl         >= 2.1.0  && <= 2.3.0
     , vector      >= 0.10.0 && <  0.12.1

--- a/stack-7.8.yaml
+++ b/stack-7.8.yaml
@@ -1,7 +1,0 @@
-resolver: lts-2.22
-packages:
-- '.'
-extra-deps:
-  - string-conv-0.1.2
-flags: {}
-extra-package-dbs: []

--- a/stack-8.2.yaml
+++ b/stack-8.2.yaml
@@ -1,4 +1,4 @@
-resolver: lts-9.21
+resolver: lts-11.22
 packages:
 - '.'
 extra-deps: []

--- a/stack-8.4.yaml
+++ b/stack-8.4.yaml
@@ -1,4 +1,4 @@
-resolver: nightly-2018-05-18
+resolver: lts-12.26
 packages:
 - '.'
 extra-deps: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-11.9
+resolver: lts-13.26
 packages:
 - '.'
 extra-deps: []


### PR DESCRIPTION
@mcfilib Hey, when you got a moment could you review this and upload to Hackage if you see fit.

This should clear the out of range dependency warnings we're seeing when building Heracles and Eros.