### PR TITLE
Monadfail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,16 @@ cache:
 # Build matrix.
 matrix:
   include:
-    - env: GHCVER=8.6.5 STACK_YAML=stack.yaml
+    - env: GHCVER=8.8.3 STACK_YAML=stack.yaml
+      compiler: GHC-8.8.3
+      addons:
+        apt:
+          sources:
+            - hvr-ghc
+          packages:
+            - ghc-8.8.3
+
+    - env: GHCVER=8.6.5 STACK_YAML=stack-8.6.yaml
       compiler: GHC-8.6.5
       addons:
         apt:

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -28,6 +28,7 @@ library
     , bytestring  >= 0.9.0   && <= 0.12.0
     , cereal      >= 0.4.0   && <  0.6.0
     , containers  >= 0.5.0   && <= 0.7.0
+    , fail        >= 4.9.0.0 && < 4.10
     , string-conv >= 0.1     && <= 0.2
     , mtl         >= 2.1.0   && <= 2.3.0
     , vector      >= 0.10.0  && <= 0.12.1.2
@@ -53,6 +54,7 @@ test-suite spec
     , bytestring
     , cereal
     , containers
+    , fail
     , hspec
     , mtl
     , string-conv

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -9,7 +9,7 @@ author: Philip Cunningham
 maintainer: hello@filib.io
 category: Data
 build-type: Simple
-tested-with: GHC == 7.8, GHC == 7.10, GHC == 8.6.5
+tested-with: GHC == 7.8.4, GHC == 7.10.3, GHC == 8.6.5, GHC == 8.8.3
 cabal-version: >= 1.10
 extra-source-files: CHANGELOG.md
 

--- a/ruby-marshal.cabal
+++ b/ruby-marshal.cabal
@@ -24,13 +24,13 @@ library
   hs-source-dirs:
     src
   build-depends:
-      base        >= 4.7    && <= 5
-    , cereal      >= 0.4.0  && <  0.6.0
-    , bytestring  >= 0.9.0  && <= 0.12.0
-    , containers  >= 0.5.0  && <= 0.7.0
-    , string-conv >= 0.1    && <= 0.2
-    , mtl         >= 2.1.0  && <= 2.3.0
-    , vector      >= 0.10.0 && <  0.12.1
+      base        >= 4.7     && <= 5
+    , bytestring  >= 0.9.0   && <= 0.12.0
+    , cereal      >= 0.4.0   && <  0.6.0
+    , containers  >= 0.5.0   && <= 0.7.0
+    , string-conv >= 0.1     && <= 0.2
+    , mtl         >= 2.1.0   && <= 2.3.0
+    , vector      >= 0.10.0  && <= 0.12.1.2
   default-language:
     Haskell2010
   exposed-modules:

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -17,6 +17,7 @@
 module Data.Ruby.Marshal.Monad where
 
 import           Control.Applicative
+import           Control.Monad.Fail           (MonadFail)
 import           Control.Monad.State.Strict   (MonadState, StateT, get, gets,
                                                lift, put)
 import           Data.Ruby.Marshal.RubyObject (RubyObject (..))
@@ -28,7 +29,7 @@ import           Prelude
 -- | Marshal monad endows the underlying Get monad with State.
 newtype Marshal a = Marshal {
   runMarshal :: StateT Cache Get a
-} deriving (Functor, Applicative, Monad, MonadState Cache)
+} deriving (Functor, Applicative, Monad, MonadFail, MonadState Cache)
 
 -- | Lift Get monad into Marshal monad.
 liftMarshal :: Get a -> Marshal a

--- a/src/Data/Ruby/Marshal/Monad.hs
+++ b/src/Data/Ruby/Marshal/Monad.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP                        #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 --------------------------------------------------------------------
@@ -17,7 +18,9 @@
 module Data.Ruby.Marshal.Monad where
 
 import           Control.Applicative
-import           Control.Monad.Fail           (MonadFail)
+import qualified Control.Monad.Fail           as Fail
+import qualified Control.Monad                as Monad
+import           Control.Monad                (join)
 import           Control.Monad.State.Strict   (MonadState, StateT, get, gets,
                                                lift, put)
 import           Data.Ruby.Marshal.RubyObject (RubyObject (..))
@@ -29,7 +32,17 @@ import           Prelude
 -- | Marshal monad endows the underlying Get monad with State.
 newtype Marshal a = Marshal {
   runMarshal :: StateT Cache Get a
-} deriving (Functor, Applicative, Monad, MonadFail, MonadState Cache)
+} deriving (Functor, Applicative, MonadState Cache)
+
+instance Monad Marshal where
+  (Marshal ma) >>= f = Marshal . join $ runMarshal . f <$> ma
+
+#if !MIN_VERSION_base(4,13,0)
+  fail = Fail.fail
+#endif
+
+instance Fail.MonadFail Marshal where
+  fail = Marshal . Monad.fail
 
 -- | Lift Get monad into Marshal monad.
 liftMarshal :: Get a -> Marshal a

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -43,26 +43,38 @@ import Data.Ruby.Marshal.Monad
 import Data.Ruby.Marshal.RubyObject
 
 -- | Character that represents NilCharlass.
+pattern NilChar :: (Eq a, Num a) => a
 pattern NilChar = 48
 -- | Character that represents FalseClass.
+pattern FalseChar :: (Eq a, Num a) => a
 pattern FalseChar = 70
 -- | Character that represents TrueClass.
+pattern TrueChar :: (Eq a, Num a) => a
 pattern TrueChar = 84
 -- | Character that represents Array.
+pattern ArrayChar :: (Eq a, Num a) => a
 pattern ArrayChar = 91
 -- | Character that represents Fixnum.
+pattern FixnumChar :: (Eq a, Num a) => a
 pattern FixnumChar = 105
 -- | Character that represents Float.
+pattern FloatChar :: (Eq a, Num a) => a
 pattern FloatChar = 102
 -- | Character that represents Hash.
+pattern HashChar :: (Eq a, Num a) => a
 pattern HashChar = 123
 -- | Character that represents IVar.
+pattern IVarChar :: (Eq a, Num a) => a
 pattern IVarChar = 73
 -- | Character that represents Object link.
+pattern ObjectLinkChar :: (Eq a, Num a) => a
 pattern ObjectLinkChar = 64
 -- | Character that represents String.
+pattern StringChar :: (Eq a, Num a) => a
 pattern StringChar = 34
 -- | Character that represents Symbol.
+pattern SymbolChar :: (Eq a, Num a) => a
 pattern SymbolChar = 58
 -- | Character that represents Symlink.
+pattern SymlinkChar :: (Eq a, Num a) => a
 pattern SymlinkChar = 59

--- a/src/Data/Ruby/Marshal/Types.hs
+++ b/src/Data/Ruby/Marshal/Types.hs
@@ -43,38 +43,26 @@ import Data.Ruby.Marshal.Monad
 import Data.Ruby.Marshal.RubyObject
 
 -- | Character that represents NilCharlass.
-pattern NilChar :: (Eq a, Num a) => a
 pattern NilChar = 48
 -- | Character that represents FalseClass.
-pattern FalseChar :: (Eq a, Num a) => a
 pattern FalseChar = 70
 -- | Character that represents TrueClass.
-pattern TrueChar :: (Eq a, Num a) => a
 pattern TrueChar = 84
 -- | Character that represents Array.
-pattern ArrayChar :: (Eq a, Num a) => a
 pattern ArrayChar = 91
 -- | Character that represents Fixnum.
-pattern FixnumChar :: (Eq a, Num a) => a
 pattern FixnumChar = 105
 -- | Character that represents Float.
-pattern FloatChar :: (Eq a, Num a) => a
 pattern FloatChar = 102
 -- | Character that represents Hash.
-pattern HashChar :: (Eq a, Num a) => a
 pattern HashChar = 123
 -- | Character that represents IVar.
-pattern IVarChar :: (Eq a, Num a) => a
 pattern IVarChar = 73
 -- | Character that represents Object link.
-pattern ObjectLinkChar :: (Eq a, Num a) => a
 pattern ObjectLinkChar = 64
 -- | Character that represents String.
-pattern StringChar :: (Eq a, Num a) => a
 pattern StringChar = 34
 -- | Character that represents Symbol.
-pattern SymbolChar :: (Eq a, Num a) => a
 pattern SymbolChar = 58
 -- | Character that represents Symlink.
-pattern SymlinkChar :: (Eq a, Num a) => a
 pattern SymlinkChar = 59

--- a/stack-8.6.yaml
+++ b/stack-8.6.yaml
@@ -1,4 +1,4 @@
-resolver: lts-15.13
+resolver: lts-13.26
 packages:
 - '.'
 extra-deps: []

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -6,7 +6,7 @@
 packages: []
 snapshots:
 - completed:
-    size: 499889
-    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/13/26.yaml
-    sha256: ecb02ee16829df8d7219e7d7fe6c310819820bf335b0b9534bce84d3ea896684
-  original: lts-13.26
+    size: 496112
+    url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/15/13.yaml
+    sha256: 75a1a0f870e1876898b117b0e443f911b3fa2985bfabb53158c81ab5765beda5
+  original: lts-15.13


### PR DESCRIPTION
Closes #61.
This PR adds the `MonadFail` instance to the `Marshal` monad, so that it works with base-4.13.0.0 and above. I haven't updated the version numbers, and leave it to you to cut a new release.

